### PR TITLE
Add `OnOwnershipTransferFailed` method to PunOwnershipCallbacksTriggers class

### DIFF
--- a/Packages/PUN2Rx/Runtime/Triggers/PunOwnershipCallbacksTriggers.cs
+++ b/Packages/PUN2Rx/Runtime/Triggers/PunOwnershipCallbacksTriggers.cs
@@ -35,6 +35,18 @@ namespace PUN2Rx
             return onOwnershipTransferred ?? (onOwnershipTransferred = new Subject<Tuple<PhotonView, Player>>());
         }
 
+        private Subject<Tuple<PhotonView, Player>> onOwnershipTransferFailed;
+
+        public void OnOwnershipTransferFailed(PhotonView targetView, Player senderOfFailedRequest)
+        {
+            onOwnershipTransferFailed?.OnNext(Tuple.Create(targetView, senderOfFailedRequest));
+        }
+
+        public IObservable<Tuple<PhotonView, Player>> OnOwnershipTransferFailedAsObservable()
+        {
+            return onOwnershipTransferFailed ?? (onOwnershipTransferFailed = new Subject<Tuple<PhotonView, Player>>());
+        }
+
         #endregion
 
         #region lifecycle

--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ OnLeftRoomAsObservable | OnNext | Unit
 `Photon.Pun.IPunOwnershipCallbacks` | |
 OnOwnershipRequestAsObservable | OnNext | Tuple&lt;PhotonView, Player&gt;
 OnOwnershipTransferredAsObservable | OnNext | Tuple&lt;PhotonView, Player&gt;
+OnOwnershipTransferFailedAsObservable | OnNext | Tuple&lt;PhotonView, Player&gt;
 
 ## Author
 [nekomimi-daimao](https://qiita.com/nekomimi-daimao)


### PR DESCRIPTION
In order to support current PUN2 version(2.33.3), add `OnOwnershipTransferFailed` callback method to PunOwnershipCallbacksTriggers class.

For the specification about `OnOwnershipTransferFailed`, please refer to https://doc-api.photonengine.com/en/pun/v2/interface_photon_1_1_pun_1_1_i_pun_ownership_callbacks.html#ae673ae63bc6e81b13a5c17bdfcb41050 .